### PR TITLE
[site] Add interactive earlgrey block diagram to site

### DIFF
--- a/site/block-diagram/block_diagram.css
+++ b/site/block-diagram/block_diagram.css
@@ -19,6 +19,9 @@
  * - Grids of blocks
  * - Highlighting by clock
  * - Subclocks (maximum of 2)
+ * - Arrows between blocks
+ * - Arrows crossing tops/chips/etc
+ * - Arrow groups (of three arrows)
  *
  * The `earlgrey.html` block diagram in this repo can be used as an example as
  * it uses all of these features.
@@ -66,10 +69,15 @@
     --status3-fg: var(--text-black);
     --status4-fg: var(--text-black);
 
+    --arrow-bg: #7b7979;
+
     --gap: 0.8em;
     --padding: 0.8em;
     --aon-width: 0.15em;
     --block-height: 2.5em;
+    --arrow-width: 0.4em;
+    --arrow-head-width: 0.8em;
+    --arrow-head-length: 0.3em;
 
     --font-size: 0.75rem;
 }
@@ -230,7 +238,7 @@
  * See the `grid="[234]"` attributes for setting the number of columns for the
  * grid of blocks.
  *
- * `.blocks` elements may contain `.block`, or `.domain.always-on`
+ * `.blocks` elements may contain `.block`, `.arrow`, or `.domain.always-on`
  * elements.
  */
 .blocks {
@@ -374,4 +382,281 @@ a.block:visited {
 .clock6, .block[subclock1="clock6"]::before, .block[subclock2="clock6"]::after {
     --clock-bg: var(--clock6-bg);
     --clock-fg: var(--clock6-fg);
+}
+
+/**********
+ * Arrows *
+ **********/
+
+/**
+ *
+ * Arrow groups allow arrows within the same row or column to be placed
+ * side-by-side.
+ *
+ * Currently, only groups of three arrows are supported. More configurations can
+ * be added fairly easily.
+ *
+ * This can be made fully general once Chromium supports `display: subgrid`.
+ */
+.arrow-group {
+    display: contents;
+}
+
+/**
+ * Arrow groups of `n` arrows are supported by checking if the `x`th child is
+ * also the `n - x`th child of an `.arrow-group`.
+ *
+ * This ensures we only apply this styling when there are exactly `n` siblings.
+ */
+.arrow-group .arrow:nth-child(1):nth-last-child(3) { --arrow-offset: calc(50% - 1.5 * var(--arrow-head-width)); }
+.arrow-group .arrow:nth-child(2):nth-last-child(2) { --arrow-offset: 50%; }
+.arrow-group .arrow:nth-child(3):nth-last-child(1) { --arrow-offset: calc(50% + 1.5 * var(--arrow-head-width)); }
+
+/**
+ * Apply the `--arrow-offset` calculated above to shift within the row or col.
+ */
+.arrow-group .arrow.row { top: var(--arrow-offset); }
+.arrow-group .arrow.column { left: var(--arrow-offset); }
+
+/**
+ * An arrow between blocks within a `.blocks` grid.
+ *
+ * Arrows have heads on both ends and can span across blocks within the grid,
+ * and extend outside of the grid to some extent.
+ *
+ * ## Attributes
+ *
+ * The following attributes can be used to position an arrow:
+ * - `arrow-x`
+ * - `arrow-y`
+ * - `arrow-span` - number of blocks spanned perpendicular to the arrow.
+ * - `arrow-length` - number of blocks spanned parallel to the arrow.
+ * - `arrow-layers` - optional number of "layers" (e.g. tops, domains, etc.)
+ *                    that the arrow extends outside of its grid of blocks.
+ *
+ * These are documented in more detail below in the arrow positioning section.
+ *
+ * ## A note on SVGs
+ *
+ * These arrows were initially implemented using SVGs by using a line with two
+ * markers added to the ends. This allowed the line to be resized without the
+ * heads stretching.
+ *
+ * This worked fine but needed a few hacks to stop the line intersecting the
+ * arrow heads. Also, in order to style these SVGs they have to be defined
+ * within the HTML document and can't be included as an image.
+ *
+ * Instead, I've switched to using a background-color for the arrow's line and
+ * `::before` and `::after` elements for the heads.
+ */
+.arrow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    position: absolute;
+    place-self: center center;
+    width: 100%;
+    height: 100%;
+
+    background-color: var(--arrow-bg);
+    background-clip: padding-box;
+}
+
+/**
+ * Like subclocks, arrow heads are added using `::before` and `::after`
+ * pseudo-classes which allow for creating new elements via CSS.
+ *
+ * The triangle shape is made by setting only one side of the element's border.
+ */
+.arrow::before, .arrow::after {
+    display: block;
+    content: "";
+    position: absolute;
+    border-color: transparent;
+    border-style: solid;
+}
+
+/**
+ * Set up the border sizes for forming the triangles.
+ */
+.arrow.row::before, .arrow.row::after {
+    border-width: calc(0.5 * var(--arrow-head-width)) 0;
+}
+.arrow.column::before, .arrow.column::after {
+    border-width: 0 calc(0.5 * var(--arrow-head-width));
+}
+
+/**
+ * Fill in the single relevant border and position each arrow head.
+ */
+.arrow.row::before {
+    border-right: var(--arrow-head-length) solid var(--arrow-bg);
+    right: 100%;
+}
+.arrow.row::after {
+    border-left: var(--arrow-head-length) solid var(--arrow-bg);
+    left: 100%;
+}
+.arrow.column::before {
+    border-bottom: var(--arrow-head-length) solid var(--arrow-bg);
+    bottom: 100%;
+}
+.arrow.column::after {
+    border-top: var(--arrow-head-length) solid var(--arrow-bg);
+    top: 100%;
+}
+
+/**
+ * Helper attributes for positioning arrows.
+ *
+ * As before, these are necessary because support for using attribute values
+ * like numbers is still experimental, so we manually convert them to CSS
+ * variables here.
+ *
+ * These are just helpers, you can specify `style="--arrow-{?}: {?}"` manually
+ * if you need another value.
+ */
+.arrow[arrow-x="1"] { --arrow-x: 1; }
+.arrow[arrow-x="2"] { --arrow-x: 2; }
+.arrow[arrow-x="3"] { --arrow-x: 3; }
+.arrow[arrow-x="4"] { --arrow-x: 4; }
+.arrow[arrow-y="1"] { --arrow-y: 1; }
+.arrow[arrow-y="2"] { --arrow-y: 2; }
+.arrow[arrow-y="3"] { --arrow-y: 3; }
+.arrow[arrow-y="4"] { --arrow-y: 4; }
+.arrow[arrow-y="5"] { --arrow-y: 5; }
+.arrow[arrow-y="6"] { --arrow-y: 6; }
+.arrow[arrow-span="2"] { --arrow-span: 2; }
+.arrow[arrow-span="3"] { --arrow-span: 3; }
+.arrow[arrow-span="4"] { --arrow-span: 4; }
+.arrow[arrow-span="5"] { --arrow-span: 5; }
+.arrow[arrow-span="6"] { --arrow-span: 6; }
+.arrow[arrow-length="1"] { --arrow-length: 1; }
+.arrow[arrow-length="2"] { --arrow-length: 2; }
+.arrow[arrow-length="3"] { --arrow-length: 3; }
+.arrow[arrow-length="4"] { --arrow-length: 4; }
+.arrow[arrow-length="5"] { --arrow-length: 5; }
+.arrow[arrow-length="6"] { --arrow-length: 6; }
+.arrow[arrow-layers="1"] { --arrow-layers: 1; }
+.arrow[arrow-layers="2"] { --arrow-layers: 2; }
+.arrow[arrow-layers="3"] { --arrow-layers: 3; }
+.arrow[arrow-layers="4"] { --arrow-layers: 4; }
+.arrow[arrow-layers="5"] { --arrow-layers: 5; }
+.arrow[arrow-layers="6"] { --arrow-layers: 6; }
+
+/**
+ * The following group of classes calculate the size and position of arrows.
+ *
+ * This isn't an easy task, but this final state is quite stable. It can be
+ * refactored to be neater at some point if needs be.
+ *
+ * ## Stages of calculation
+ *
+ * The general tactic is to calculate the arrow's length in four parts and
+ * collect them all together at the end:
+ *
+ * - arrow-len-base: the base length of an arrow, e.g. the grid cells it spans
+ * - arrow-len-gaps: the extra space needed to span the gaps at either end
+ * - arrow-len-layers: the extra space needed for arrows to extend out of the
+ *                     grid of blocks into other layers.
+ *
+ * ## Sizing strategy
+ *
+ * Took a little while to work out how to get these arrows to always be the
+ * right lengths when the grid sizes are calculated dynamically.
+ *
+ * Here is the strategy:
+ *
+ * - For arrows of length `l > 2`, we place the arrow across the middle `l - 2`
+ *   blocks. This means the arrow heads poke out of the ends no matter the size
+ *   of the grid cells.
+ * - For arrows of length `l = 2`, we place the arrow within the first grid cell
+ *   only and position is so that it starts after.
+ * - For arrows of length `l = 1`, we give them no base length. These arrows are
+ *   likely reaching out of a blog grid using `arrow-layers` and don't span
+ *   between any blocks.
+ */
+
+/**
+ * The lengths for most arrows: 100% + two gaps either side.
+ */
+.arrow {
+    --arrow-len-base: 100%;
+    /* Maps arrow lengths (in grid cells) to the number of gaps they must span:
+     *  1  => no gaps: these arrows don't cross between any blocks.
+     *  2  => one gap: these arrows cross one gap between two blocks.
+     *  >2 => two gaps: these arrows span the middle blocks plus a gap each end.
+     */
+    --arrow-num-gaps: min(calc(var(--arrow-length) - 1), 2);
+    --arrow-len-gaps: calc(var(--arrow-num-gaps) * var(--gap));
+}
+
+.arrow[arrow-length="1"], .arrow[arrow-length="2"] {
+    /* These arrows don't span any blocks, so don't include grid cell size */
+    --arrow-len-base: 0%;
+}
+
+.arrow[arrow-layers] {
+    /* Arrows going outside the grid will cross one to another layer */
+    --arrow-len-layers: calc(var(--arrow-layers) * var(--padding) + var(--gap));
+    /* Plus include the gap of the side which stays within the grid */
+    --arrow-len-gaps: calc(var(--gap));
+}
+.arrow[arrow-layers][arrow-length="1"] {
+    /* Unlike above, external arrows with length "1" don't cross any gaps */
+    --arrow-len-gaps: 0px;
+    /* Also ensure they appear above domain backgrounds etc. */
+    z-index: 2;
+}
+
+/**
+ * Position arrows leaving the grid at the end of their grid cell
+ */
+.arrow.row[arrow-layers] {
+    left: calc(var(--arrow-head-length) - var(--gap));
+}
+.arrow.column[arrow-layers] {
+    top: calc(var(--arrow-head-length) - var(--gap));
+}
+
+/**
+ * Positioning for normal horizontal (row) arrows
+ */
+.arrow.row {
+    width: calc(var(--arrow-len-base) - 2 * var(--arrow-head-length) + var(--arrow-len-gaps) + var(--arrow-len-layers, 0px));
+    height: var(--arrow-width);
+    grid-row-start: var(--arrow-y);
+    grid-row-end: span var(--arrow-span, 1);
+    /* Span the middle `length - 2` blocks, pointing to the end two */
+    grid-column-start: calc(var(--arrow-x) + 1);
+    grid-column-end: span calc(var(--arrow-length) - 2);
+}
+
+/**
+ * Positioning for normal vertical (column) arrows
+ */
+.arrow.column {
+    height: calc(var(--arrow-len-base) - 2 * var(--arrow-head-length) + var(--arrow-len-gaps) + var(--arrow-len-layers, 0px));
+    width: var(--arrow-width);
+    grid-column-start: var(--arrow-x);
+    grid-column-end: span var(--arrow-span, 1);
+    /* Span the middle `length - 2` blocks, pointing to the end two */
+    grid-row-start: calc(var(--arrow-y) + 1);
+    grid-row-end: span calc(var(--arrow-length) - 2);
+}
+
+/**
+ * Arrows of length 1 or 2 actually only span a single cell: the first.
+ * They're positioned to begin at the end and span to the next cell.
+ */
+.arrow.row[arrow-length="1"], .arrow.row[arrow-length="2"] {
+    grid-column-start: var(--arrow-x);
+    grid-column-end: span 1;
+    left: calc(100% + var(--arrow-head-length));
+}
+.arrow.column[arrow-length="1"], .arrow.column[arrow-length="2"] {
+    grid-row-start: var(--arrow-y);
+    grid-row-end: span 1;
+    top: calc(100% + var(--arrow-head-length));
 }

--- a/site/block-diagram/block_diagram.css
+++ b/site/block-diagram/block_diagram.css
@@ -60,6 +60,13 @@
     --clock5-fg: var(--text-black);
     --clock6-fg: var(--text-black);
 
+    --tooltip-bg: #333;
+    --tooltip-fg: var(--text-white);
+    --tooltip-title-bg: #666;
+    --tooltip-title-fg: var(--text-white);
+    --tooltip-arrow-width: 0.8em;
+    --tooltip-arrow-height: 0.7em;
+
     --status1-bg: #b81d13;
     --status2-bg: #efb700;
     --status3-bg: #82be00;
@@ -67,7 +74,7 @@
     --status1-fg: var(--text-white);
     --status2-fg: var(--text-black);
     --status3-fg: var(--text-black);
-    --status4-fg: var(--text-black);
+    --status4-fg: var(--text-white);
 
     --arrow-bg: #7b7979;
 
@@ -382,6 +389,134 @@ a.block:visited {
 .clock6, .block[subclock1="clock6"]::before, .block[subclock2="clock6"]::after {
     --clock-bg: var(--clock6-bg);
     --clock-fg: var(--clock6-fg);
+}
+
+/************
+ * Tooltips *
+ ************/
+
+.block:hover {
+    z-index: 3;
+}
+.block:not(:hover) .tooltip {
+    display: none;
+}
+
+.tooltip {
+    display: grid;
+    grid-template-columns: minmax(4.5em, auto) 1fr;
+    column-gap: 0.5em;
+    row-gap: 0.25em;
+
+    pointer-events: none;
+
+    position: absolute;
+    overflow: visible;
+
+    width: max-content;
+    padding: var(--padding);
+
+    transform: translateX(-50%);
+    top: calc(100% + 0.5 * var(--tooltip-arrow-height));
+    left: calc(50%);
+    right: 0;
+    margin-left: auto;
+    margin-right: auto;
+
+    border-radius: 0.4em;
+    background: var(--tooltip-bg);
+    color: var(--tooltip-fg);
+
+    font-size: 0.75rem;
+}
+
+.tooltip::before {
+    display: block;
+    content: "";
+    z-index: 99;
+
+    position: absolute;
+    bottom: 100%;
+    transform: translateX(-50%);
+    left: 50%;
+
+    border-width: 0 var(--tooltip-arrow-width);
+    border-style: solid;
+    border-color: transparent;
+    border-bottom: var(--tooltip-arrow-height) solid var(--tooltip-bg);
+}
+
+.tooltip-title {
+    grid-column: span 2;
+    padding: 0.2em 0.4em;
+    margin-top: 0;
+    margin-bottom: 0.2em;
+
+    border-radius: 0.3em;
+    background: var(--tooltip-title-bg);
+    color: var(--tooltip-title-fg);
+
+    white-space: nowrap;
+    font-weight: bold;
+}
+
+.tooltip hr {
+    grid-column: span 2;
+    width: 100%;
+    margin: 0.2em 0;
+    height: 0;
+}
+
+.tooltip .value {
+    position: relative;
+    font-weight: bold;
+}
+
+.status1 {
+    --status-bg: var(--status1-bg);
+    --status-fg: var(--status1-fg);
+}
+.status2 {
+    --status-bg: var(--status2-bg);
+    --status-fg: var(--status2-fg);
+}
+.status3 {
+    --status-bg: var(--status3-bg);
+    --status-fg: var(--status3-fg);
+}
+.status4 {
+    --status-bg: var(--status4-bg);
+    --status-fg: var(--status4-fg);
+}
+
+.tooltip .status::before {
+    display: block;
+    content: "";
+
+    position: absolute;
+    transform: translateY(-50%);
+    top: 50%;
+    left: 0;
+    right: 0;
+
+    width: 0.7em;
+    height: 0.7em;
+
+    border-radius: 100%;
+    background-color: var(--status-bg);
+    color: var(--status-fg);
+}
+
+.tooltip .percentage {
+    padding: 0.1em 1em;
+    margin: -0.1em 0;
+    border-radius: 0.3em;
+    background-color: var(--status-bg);
+    color: var(--status-fg);
+}
+
+.tooltip .label {
+    justify-self: start;
 }
 
 /**********

--- a/site/block-diagram/block_diagram.css
+++ b/site/block-diagram/block_diagram.css
@@ -1,0 +1,377 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * This is a CSS library for building block diagrams out of simple semantic HTML.
+ *
+ * We're not CSS engineers, so I've done my best not to include hacks, unstable
+ * features, or massive complexity. Remaining complexity will be documented
+ * or wrapped into variables to make intent clear.
+ *
+ * Most styling is configurable through variables within `.block-diagram`.
+ *
+ * The supported features/components are:
+ * - Tops
+ * - Domains
+ * - Top and domain labels
+ * - Always-on domains
+ * - Grids of blocks
+ * - Highlighting by clock
+ * - Subclocks (maximum of 2)
+ *
+ * The `earlgrey.html` block diagram in this repo can be used as an example as
+ * it uses all of these features.
+ */
+
+/**
+ * The root component of the whole block diagram.
+ *
+ * The following variables can be used to configure the styling of the diagram.
+ * These defaults can be overridden by re-defining the variables on a specific diagram.
+ */
+.block-diagram {
+    --text-white: #ffffff;
+    --text-black: #000000;
+
+    --diagram-bg: #ffffff;
+    --diagram-fg: var(--text-black);
+
+    --top-bg: #f8f8ff;
+    --top-fg: var(--text-black);
+
+    --domain-bg: #e9e9e9;
+    --domain-fg: var(--text-black);
+    --always-on: #dc143c;
+
+    --clock1-bg: #8bd6df;
+    --clock2-bg: #6395ae;
+    --clock3-bg: #cfbde4;
+    --clock4-bg: #967ebf;
+    --clock5-bg: #f9ad38;
+    --clock6-bg: #d4d4d2;
+    --clock1-fg: var(--text-black);
+    --clock2-fg: var(--text-white);
+    --clock3-fg: var(--text-black);
+    --clock4-fg: var(--text-white);
+    --clock5-fg: var(--text-black);
+    --clock6-fg: var(--text-black);
+
+    --status1-bg: #b81d13;
+    --status2-bg: #efb700;
+    --status3-bg: #82be00;
+    --status4-bg: #008450;
+    --status1-fg: var(--text-white);
+    --status2-fg: var(--text-black);
+    --status3-fg: var(--text-black);
+    --status4-fg: var(--text-black);
+
+    --gap: 0.8em;
+    --padding: 0.8em;
+    --aon-width: 0.15em;
+    --block-height: 2.5em;
+
+    --font-size: 0.75rem;
+}
+
+/**
+ * Lay the root out vertically. Various grids are used for horizontal layout
+ * within the block diagram.
+ *
+ * Block diagrams can be given a `.block-diagram-title`.
+ */
+.block-diagram {
+    display: flex;
+    flex-direction: column;
+    padding: var(--padding);
+    gap: var(--gap);
+
+    background-color: var(--diagram-bg);
+    color: var(--diagram-fg);
+}
+
+.block-diagram .block-diagram-title {
+    font-size: var(--font-size);
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+/********
+ * Tops *
+ ********/
+
+/**
+ * Represents a chip top-level. Can be given a `.top-title`.
+ *
+ * Tops should typically contain `.domains` or `.domain` components.
+ */
+.top {
+    display: flex;
+    flex-direction: column;
+    padding: var(--padding);
+
+    background-color: var(--top-bg);
+    color: var(--top-fg);
+
+    z-index: 3;
+}
+
+.top .top-title {
+    margin: 0;
+    font-size: var(--font-size);
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+/****************
+ * Grid helpers *
+ ****************/
+
+/**
+ * Helper attributes to specify grids with a certain number of columns.
+ *
+ * Currently only 2, 3, and 4 column grids have helpers. This can be extended
+ * to any number once the CSS `attr()` function supports numeric values.
+ */
+[grid="2"] { grid-template-columns: repeat(2, 1fr); }
+[grid="3"] { grid-template-columns: repeat(3, 1fr); }
+[grid="4"] { grid-template-columns: repeat(4, 1fr); }
+
+/**
+ * Helper attributes to specify the number of rows or columns a block spans.
+ *
+ * Currently only spans of 2 - 6 blocks have helpers. This can be extended to
+ * any number once the CSS `attr()` function supports numeric values.
+ */
+[grid-rows="2"] { grid-row: span 2; }
+[grid-rows="3"] { grid-row: span 3; }
+[grid-rows="4"] { grid-row: span 4; }
+[grid-rows="5"] { grid-row: span 5; }
+[grid-rows="6"] { grid-row: span 6; }
+[grid-cols="2"] { grid-column: span 2; }
+[grid-cols="3"] { grid-column: span 3; }
+[grid-cols="4"] { grid-column: span 4; }
+[grid-cols="5"] { grid-column: span 5; }
+[grid-cols="6"] { grid-column: span 6; }
+
+/***********
+ * Domains *
+ ***********/
+
+/**
+ * Group of grid-arranged domains.
+ *
+ * Use the `grid="[234]"` attribute to set the number of domains side-by-side.
+ */
+.domains {
+    display: grid;
+    gap: var(--gap);
+}
+
+/**
+ * Domain boundary. Can be given a `.domain-title`.
+ *
+ * Domains should be placed within `.top` or `.domains` elements.
+ */
+.domain {
+    display: block;
+
+    position: relative;
+    padding: var(--padding);
+    border-radius: 0.25em;
+
+    background-color: var(--domain-bg);
+    color: var(--domain-fg);
+}
+
+/**
+ * Domains may optionally have the `.always-on` class which will outline their
+ * blocks.
+ *
+ * These domains can be placed wherever regular domains can, plus also within
+ * `.blocks` elements to surround a subset of blocks.
+ *
+ * Domains can be given a `.domain-title`.
+ */
+.domain.always-on {
+    background-color: transparent;
+    border: var(--aon-width) dashed var(--always-on);
+    padding: calc(var(--padding) - var(--aon-width));
+}
+
+.blocks .domain.always-on {
+    /* Places the AON domain border in the middle of the gaps between blocks */
+    padding: calc(0.5 * var(--padding) - var(--aon-width));
+    margin: calc(-0.5 * var(--padding));
+}
+
+.domain .domain-title {
+    font-size: var(--font-size);
+    font-weight: bold;
+    text-transform: uppercase;
+    padding: 0;
+    margin: 0;
+}
+
+.domain.always-on .domain-title {
+    margin-top: calc(-0.5 * var(--padding));
+    font-size: var(--font-size);
+    text-align: right;
+    color: var(--always-on);
+}
+
+/**********
+ * Blocks *
+ **********/
+
+/**
+ * Group of blocks arranged in a grid.
+ *
+ * See the `grid="[234]"` attributes for setting the number of columns for the
+ * grid of blocks.
+ *
+ * `.blocks` elements may contain `.block`, or `.domain.always-on`
+ * elements.
+ */
+.blocks {
+    display: grid;
+    grid-auto-rows: minmax(var(--block-height), auto);
+    gap: var(--gap);
+    position: relative;
+}
+
+/**
+ * Individual block within a `.blocks` grid.
+ *
+ * ## Clocks
+ *
+ * Blocks can be given a class `.clock[123456]` to specify their clock speed,
+ * plus optional `subclock1="clock[123456]"` and `subclock2="clock[123456]"`
+ * attributes to specify up to two sub-clock speeds.
+ *
+ * ## Positioning
+ *
+ * Blocks are positioned automatically in left-to-right reading order.
+ * A block's size can be set using the `grid-rows` and `grid-cols` attributes.
+ */
+.block {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+
+    position: relative;
+    z-index: 2;
+
+    padding: calc(0.3 * var(--padding));
+    border-radius: 0.5em;
+
+    font-size: var(--font-size);
+    text-decoration: none;
+
+    background-color: var(--clock-bg);
+    color: var(--clock-fg);
+}
+
+a.block:visited {
+    background-color: var(--clock-bg);
+    color: var(--clock-fg);
+}
+
+/**
+ * Subclocks are implemented using `::before` and `::after` CSS classes. This
+ * lets us create new elements through CSS only, but it does limit us to two
+ * subclocks.
+ *
+ * More than two seems unlikely, but this can be supported by adding elements
+ * representing subclocks into the HTML itself.
+ */
+.block[subclock1]::before, .block[subclock2]::after {
+    display: block;
+    content: "";
+
+    position: absolute;
+    left: calc(0.75 * var(--padding));
+
+    width: 0.75em;
+    height: 0.75em;
+    border-radius: 0.25em;
+}
+
+.block[subclock1]::before {
+    top: calc(0.75 * var(--padding));
+    background-color: var(--clock-bg);
+}
+
+.block[subclock2]::after {
+    bottom: calc(0.75 * var(--padding));
+    background-color: var(--clock-bg);
+}
+
+/**********
+ * Clocks *
+ **********/
+
+/**
+ * Legend of clock colours arranged in a row.
+ */
+.clocks {
+    display: grid;
+    grid-auto-columns: minmax(0, 1fr);
+    grid-auto-flow: column;
+    gap: var(--gap);
+
+    width: fit-content;
+}
+
+/**
+ * An individual clock in the legend of clocks.
+ *
+ * Apply each of the `.clock[123456]` classes to these elements to give them
+ * the correct colours.
+ */
+.clocks .clock {
+    text-align: center;
+
+    padding: calc(0.5 * var(--padding)) var(--padding);
+    border-radius: 0.5em;
+    font-size: var(--font-size);
+    white-space: nowrap;
+
+    background-color: var(--clock-bg);
+    color: var(--clock-fg);
+}
+
+/**
+ * Colours for the `.clock[123456]` classes and the corresponding subclocks.
+ */
+
+.clock1, .block[subclock1="clock1"]::before, .block[subclock2="clock1"]::after {
+    --clock-bg: var(--clock1-bg);
+    --clock-fg: var(--clock1-fg);
+}
+
+.clock2, .block[subclock1="clock2"]::before, .block[subclock2="clock2"]::after {
+    --clock-bg: var(--clock2-bg);
+    --clock-fg: var(--clock2-fg);
+}
+
+.clock3, .block[subclock1="clock3"]::before, .block[subclock2="clock3"]::after {
+    --clock-bg: var(--clock3-bg);
+    --clock-fg: var(--clock3-fg);
+}
+
+.clock4, .block[subclock1="clock4"]::before, .block[subclock2="clock4"]::after {
+    --clock-bg: var(--clock4-bg);
+    --clock-fg: var(--clock4-fg);
+}
+
+.clock5, .block[subclock1="clock5"]::before, .block[subclock2="clock5"]::after {
+    --clock-bg: var(--clock5-bg);
+    --clock-fg: var(--clock5-fg);
+}
+
+.clock6, .block[subclock1="clock6"]::before, .block[subclock2="clock6"]::after {
+    --clock-bg: var(--clock6-bg);
+    --clock-fg: var(--clock6-fg);
+}

--- a/site/block-diagram/block_diagram.js
+++ b/site/block-diagram/block_diagram.js
@@ -1,0 +1,158 @@
+/* Copyright lowRISC contributors.
+ * Licensed under the Apache License, Version 2.0, see LICENSE for details.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Fetch the latest stats for a block diagram and add them as tooltips.
+ *
+ * @param statsURL URL to the JSON stats report file for this block diagram.
+ * @param blocks   Collection of HTMLElements for the block-diagram's blocks.
+ */
+async function loadTooltips(statsURL, blocks) {
+    // Fetch the latest stats report
+    const req = new XMLHttpRequest();
+    req.onload = (event) => {
+        const stats = JSON.parse(req.response);
+        // Assign data to each block
+        for (block of blocks) {
+            const tooltip = buildTooltip(stats[block.id]);
+            block.appendChild(tooltip);
+        }
+    };
+    req.open("GET", statsURL, true);
+    req.send();
+}
+/*
+
+/**
+ * Build a tooltip HTML element.
+ *
+ * Currently always builds the EDN elements. Would like it to take JSON for the
+ * parameters.
+ *
+ * @param stats Object of stats for this block with these properties:
+ *     * name
+ *     * version
+ *     * design_stage (may be null)
+ *     * verification_stage (may be null)
+ *     * total_runs (may be null)
+ *     * total_passing (may be null)
+ * @return A HTMLElement tooltip built from the given stats.
+ */
+function buildTooltip(stats) {
+    let children = [
+        buildElement("p", "tooltip-title", `${stats.name} v${stats.version}`),
+    ];
+
+    // Append the design and verification stages if the block has them
+    if (stats.design_stage && stats.verification_stage) {
+        // Get status classes for design and verification stages
+        const design_status = getStageStatus(stats.design_stage);
+        const verification_status = getStageStatus(stats.verification_stage);
+
+        children = children.concat([
+            buildElement(
+                "span",
+                `value status ${design_status}`,
+                stats.design_stage
+            ),
+            buildElement("span", "label", "design"),
+            buildElement(
+                "span",
+                `value status ${verification_status}`,
+                stats.verification_stage
+            ),
+            buildElement("span", "label", "verification"),
+        ]);
+    }
+
+    // Append test status if the block has it
+    if (stats.total_runs && stats.total_passing) {
+        // Calculate passing percentage and status class
+        const passing = Math.floor(
+            100 * stats.total_passing / stats.total_runs
+        );
+        const passing_status = getPassingStatus(passing);
+
+        children = children.concat([
+            buildElement("hr"),
+            buildElement("span", "value", stats.total_runs),
+            buildElement("span", "label", "tests"),
+            buildElement(
+                "span",
+                `value percentage ${passing_status}`,
+                `${passing}%`
+            ),
+            buildElement("span", "label", "passing"),
+        ]);
+    }
+
+    let tooltip = document.createElement("div");
+    tooltip.className = "tooltip";
+
+    for (child of children) {
+        tooltip.appendChild(child);
+    }
+
+    return tooltip;
+}
+
+/**
+ * Convenience function to build an element with the given classes and content.
+ */
+function buildElement(tag, classes = "", content = "") {
+    let element = document.createElement(tag);
+    element.className = classes;
+    element.textContent = content;
+    return element;
+}
+
+/**
+ * Gets the `status[1234]` class for a design or verification stage.
+ *
+ * @param stage A design or verification stage, or "N/A".
+ * @return String of the `status[1234]` class corresponding to this stage.
+ */
+function getStageStatus(stage) {
+    switch (stage) {
+        case "N/A":
+            return "";
+        case "D0":
+        case "V0":
+            return "status1";
+        case "D1":
+        case "V1":
+            return "status2";
+        case "D2":
+        case "V2":
+        case "D2S":
+        case "V2S":
+            return "status3";
+        case "D3":
+        case "V3":
+            return "status4";
+        default:
+            throw `unknown stage "${stage}"`;
+    }
+}
+
+/**
+ * Gets the `status[1234]` class for a passing-rate percentage.
+ *
+ * @param passing Percentage in [0, 100] of how many tests are passing.
+ * @returns String of the `status[1234]` class corresponding to this percentage.
+ */
+function getPassingStatus(passing) {
+    if (passing <= 45) {
+        return "status1";
+    } else if (passing <= 90) {
+        return "status2";
+    } else if (passing < 100) {
+        return "status3";
+    } else if (passing == 100) {
+        return "status4";
+    } else {
+        throw `invalid passing percentage "${passing}"`
+    }
+}

--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -32,6 +32,14 @@ SPDX-License-Identifier: Apache-2.0
                     <a class="block clock1" href="https://docs.opentitan.org/hw/ip/flash_ctrl/" id="flash">Flash</a>
                     <a class="block clock1" href="https://docs.opentitan.org/hw/ip/FIXME" id="entropy-source">Entropy Source</a>
                     <a class="block clock3" href="https://docs.opentitan.org/hw/ip/usb/usbdev/" id="usb" subclock1="clock5">USB</a>
+                    <div class="arrow column" arrow-x="1" arrow-y="2" arrow-length="2" arrow-span="2"></div>
+                    <div class="arrow column" arrow-x="3" arrow-y="1" arrow-length="3"></div>
+                    <div class="arrow column" arrow-x="4" arrow-y="1" arrow-length="3"></div>
+                    <div class="arrow column" arrow-x="1" arrow-y="3" arrow-length="4"></div>
+                    <div class="arrow column" arrow-x="2" arrow-y="3" arrow-length="4"></div>
+                    <div class="arrow column" arrow-x="3" arrow-y="3" arrow-length="4"></div>
+                    <div class="arrow column" arrow-x="4" arrow-y="3" arrow-length="4"></div>
+                    <div class="arrow row" arrow-x="4" arrow-y="3" arrow-length="1" arrow-layers="2"></div>
                 </div>
             </div>
             <div class="domain">
@@ -59,8 +67,21 @@ SPDX-License-Identifier: Apache-2.0
                             <a class="block clock4" href="https://docs.opentitan.org/hw/ip/pinmux/" id="pinmux-padctrl">Pinmux / Padctrl</a>
                             <a class="block clock4" href="https://docs.opentitan.org/hw/ip/adc_ctrl/" id="adc-controller" subclock1="clock5">ADC Controller</a>
                             <a class="block clock4" href="https://docs.opentitan.org/hw/top_earlgrey/ip/sensor_ctrl/doc/" id="sensor-control" subclock1="clock5">Sensor Control</a>
+                            <div class="arrow row" arrow-x="0" arrow-y="1" arrow-length="4"></div>
+                            <div class="arrow row" arrow-x="0" arrow-y="2" arrow-length="4"></div>
+                            <div class="arrow row" arrow-x="0" arrow-y="3" arrow-length="4"></div>
+                            <div class="arrow column" arrow-x="1" arrow-y="3" arrow-length="1" arrow-layers="3"></div>
+                            <div class="arrow column" arrow-x="2" arrow-y="3" arrow-length="1" arrow-layers="3"></div>
+                            <div class="arrow-group">
+                                <div class="arrow column" arrow-x="3" arrow-y="3" arrow-length="1" arrow-layers="3"></div>
+                                <div class="arrow column" arrow-x="3" arrow-y="2" arrow-length="3" arrow-layers="3"></div>
+                                <div class="arrow column" arrow-x="3" arrow-y="1" arrow-length="4" arrow-layers="3"></div>
+                            </div>
                         </div>
                     </div>
+                    <div class="arrow row" arrow-x="1" arrow-y="1" arrow-length="4"></div>
+                    <div class="arrow row" arrow-x="1" arrow-y="2" arrow-length="4"></div>
+                    <div class="arrow row" arrow-x="1" arrow-y="3" arrow-length="4"></div>
                 </div>
             </div>
         </div>
@@ -69,6 +90,7 @@ SPDX-License-Identifier: Apache-2.0
         <div class="blocks" grid="4">
             <a class="block clock6" href="https://docs.opentitan.org/hw/top_earlgrey/ip/pinmux/autogen/pinout_asic/" id="padding" grid-cols="3">Padding (only wire and pad instances)</a>
             <a class="block clock4" href="https://docs.opentitan.org/hw/top_earlgrey/ip/ast/doc/" id="analog-sensor-top" subclock1="clock3" subclock2="clock5">Analog Sensor Top</a>
+            <div class="arrow row" arrow-x="3" arrow-y="1" arrow-length="2"></div>
         </div>
     </div>
     <div class="clocks">

--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -4,13 +4,13 @@ Licensed under the Apache License, Version 2.0, see LICENSE for details.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-<link href="block_diagram.css" rel="stylesheet">
-<script src="block_diagram.js"></script>
+<link href="/css/block_diagram.css" rel="stylesheet">
+<script src="/js/block_diagram.js"></script>
 <script>
 // Append tooltips to each block on window load.
 window.onload = (event) => {
     const blocks = document.querySelectorAll("#earlgrey-block-diagram .block");
-    loadTooltips("/earlgrey-stats.json", blocks);
+    loadTooltips("/reports/earlgrey-stats.json", blocks);
 }
 </script>
 
@@ -113,13 +113,6 @@ window.onload = (event) => {
 
 <!-- Specific stylings for this diagram -->
 <style>
-#earlgrey-block-diagram {
-    margin: 1em;
-    width: 50em;
-    background-color: #ffffff;
-    font-family: sans-serif;
-}
-
 #interior-aon-domain {
     /* Merge this AON domain into the exterior */
     border-bottom: calc(var(--aon-width) + 1px) solid var(--diagram-bg);

--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -5,6 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <link href="block_diagram.css" rel="stylesheet">
+<script src="block_diagram.js"></script>
+<script>
+// Append tooltips to each block on window load.
+window.onload = (event) => {
+    const blocks = document.querySelectorAll("#earlgrey-block-diagram .block");
+    loadTooltips("/earlgrey-stats.json", blocks);
+}
+</script>
 
 <figure class="block-diagram" id="earlgrey-block-diagram">
     <figcaption class="block-diagram-title">Chip_Earlgrey_ASIC</figcaption>

--- a/site/block-diagram/earlgrey.html
+++ b/site/block-diagram/earlgrey.html
@@ -1,0 +1,106 @@
+<!--
+Copyright lowRISC contributors.
+Licensed under the Apache License, Version 2.0, see LICENSE for details.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<link href="block_diagram.css" rel="stylesheet">
+
+<figure class="block-diagram" id="earlgrey-block-diagram">
+    <figcaption class="block-diagram-title">Chip_Earlgrey_ASIC</figcaption>
+    <div class="top">
+        <h2 class="top-title">Top_Earlgrey</h2>
+        <div class="domains" grid="2">
+            <div class="domain">
+                <h3 class="domain-title">High speed domain</h2>
+                <div class="blocks" grid="4">
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/rv_core_ibex/doc/" id="ibex" grid-rows="2" grid-cols="2"><b>Ibex Core</b> (rv32imcb)</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip_templates/rv_plic/doc/" id="interrupt-controller">Interrupt Controller</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/rom_ctrl/" id="rom">ROM</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/rv_dm/" id="debug-module">Debug Module</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/sram_ctrl/" id="main-sram">Main<br>SRAM</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/tlul/" id="high-speed-crossbar" grid-cols="4">TL-UL<br>Crossbar</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/keymgr/" id="key-manager">Key Manager</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/kmac/" id="kmac">KMAC</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/edn/" id="edn">EDN</a>
+                    <a class="block clock2" href="https://docs.opentitan.org/hw/ip/spi_host/" id="spi-host-0">SPI<br>Host 0</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/otbn/" id="otbn">OTBN</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/hmac/" id="hmac">HMAC</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/csrng/" id="csrng">CSRNG</a>
+                    <a class="block clock3" href="https://docs.opentitan.org/hw/ip/spi_host/" id="spi-host-1">SPI<br>Host 1</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/aes/" id="aes">AES</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/flash_ctrl/" id="flash">Flash</a>
+                    <a class="block clock1" href="https://docs.opentitan.org/hw/ip/FIXME" id="entropy-source">Entropy Source</a>
+                    <a class="block clock3" href="https://docs.opentitan.org/hw/ip/usb/usbdev/" id="usb" subclock1="clock5">USB</a>
+                </div>
+            </div>
+            <div class="domain">
+                <h3 class="domain-title">Peripheral domain</h2>
+                <div class="blocks" grid="4">
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/tlul/" id="peripheral-crossbar" grid-rows="6">TL-UL Crossbar</a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/otp_ctrl/" id="otp-fuse-controller">OTP (Fuse) Controller</a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/lc_ctrl/" id="life-cycle">Life<br>Cycle</a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip_templates/alert_handler/doc/" id="alert-handler">Alert Handler</a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/uart/" id="uart">4 x UART</a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/rv_timer/" id="timers">Timers</a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/gpio/" id="gpio">GPIO</a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/i2c/" id="i2c"><span>3 x I<sup>2</sup>C</span></a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/spi_device/" id="spi-device" subclock1="clock1">SPI<br>Device</a>
+                    <a class="block clock4" href="https://docs.opentitan.org/hw/ip/pattgen/" id="pattern-generators">Pattern Generators</a>
+                    <div class="domain always-on" grid-rows="3" grid-cols="3" id="interior-aon-domain">
+                        <h3 class="domain-title">Always-on domain</h2>
+                        <div class="blocks" grid="3">
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/ip/pwm/" id="pwm" subclock1="clock5">PWM</a>
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/ip/sram_ctrl/" id="retention-sram">Retention SRAM</a>
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/ip/pwrmgr/" id="power-manager" subclock1="clock5">Power Manager</a>
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/ip/sysrst_ctrl/" id="sysrst-controller" subclock1="clock5">Sysrst Controller</a>
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/ip/aon_timer/" id="aon-timers" subclock1="clock5">AON<br>Timers</a>
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/ip/clkmgr/" id="clkrst-managers" subclock1="clock5">Clk/Rst Managers</a>
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/ip/pinmux/" id="pinmux-padctrl">Pinmux / Padctrl</a>
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/ip/adc_ctrl/" id="adc-controller" subclock1="clock5">ADC Controller</a>
+                            <a class="block clock4" href="https://docs.opentitan.org/hw/top_earlgrey/ip/sensor_ctrl/doc/" id="sensor-control" subclock1="clock5">Sensor Control</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="domain always-on">
+        <div class="blocks" grid="4">
+            <a class="block clock6" href="https://docs.opentitan.org/hw/top_earlgrey/ip/pinmux/autogen/pinout_asic/" id="padding" grid-cols="3">Padding (only wire and pad instances)</a>
+            <a class="block clock4" href="https://docs.opentitan.org/hw/top_earlgrey/ip/ast/doc/" id="analog-sensor-top" subclock1="clock3" subclock2="clock5">Analog Sensor Top</a>
+        </div>
+    </div>
+    <div class="clocks">
+        <div class="clock clock1">~100 MHz</div>
+        <div class="clock clock2">96 MHz</div>
+        <div class="clock clock3">48 MHz</div>
+        <div class="clock clock4">24 HMz</div>
+        <div class="clock clock5">200 kHz</div>
+        <div class="clock clock6">Logic Only</div>
+    </div>
+</figure>
+
+<!-- Specific stylings for this diagram -->
+<style>
+#earlgrey-block-diagram {
+    margin: 1em;
+    width: 50em;
+    background-color: #ffffff;
+    font-family: sans-serif;
+}
+
+#interior-aon-domain {
+    /* Merge this AON domain into the exterior */
+    border-bottom: calc(var(--aon-width) + 1px) solid var(--diagram-bg);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    padding-bottom: calc(2.0 * var(--padding) + var(--gap) + var(--aon-width));
+    margin-bottom: calc(-2.0 * var(--padding) - var(--gap) - var(--aon-width));
+}
+
+#high-speed-crossbar {
+    /* Boost high speed crossbar to fill remaining space */
+    height: calc(2.5em + 1rem);
+}
+</style>

--- a/site/landing/assets/scss/_block-diagram.scss
+++ b/site/landing/assets/scss/_block-diagram.scss
@@ -1,0 +1,4 @@
+.block-diagram {
+    margin: 2em auto;
+    width: 50em;
+}

--- a/site/landing/assets/scss/single.scss
+++ b/site/landing/assets/scss/single.scss
@@ -3,6 +3,7 @@
 @import "base";
 @import "content-body";
 @import "boxes";
+@import "block-diagram";
 @import "main-header";
 @import "scheme-toggle";
 @import "footer";

--- a/site/landing/content/documentation.md
+++ b/site/landing/content/documentation.md
@@ -8,7 +8,7 @@ title: "Documentation"
 
 [OpenTitan](https://opentitan.org/) is an open source silicon Root of Trust (RoT) project. OpenTitan will make the silicon RoT design and implementation more transparent, trustworthy, and secure for enterprises, platform providers, and chip manufacturers. OpenTitan is administered by lowRISC CIC as a [collaborative project]({{< doc-url >}}doc/project_governance{{< /doc-url >}}) to produce high quality, open IP for instantiation as a full-featured product. This repository exists to enable collaboration across partners participating in the OpenTitan project.
 
-{{< earlgrey-diagram >}}
+{{< earlgrey-block-diagram >}}
 
 ## Getting Started
 

--- a/site/landing/layouts/shortcodes/earlgrey-block-diagram.html
+++ b/site/landing/layouts/shortcodes/earlgrey-block-diagram.html
@@ -1,0 +1,1 @@
+../../../block-diagram/earlgrey.html

--- a/site/landing/static/css/block_diagram.css
+++ b/site/landing/static/css/block_diagram.css
@@ -1,0 +1,1 @@
+../../../block-diagram/block_diagram.css

--- a/site/landing/static/js/block_diagram.js
+++ b/site/landing/static/js/block_diagram.js
@@ -1,0 +1,1 @@
+../../../block-diagram/block_diagram.js

--- a/util/site/blocks.json
+++ b/util/site/blocks.json
@@ -1,0 +1,236 @@
+{
+    "high-speed-crossbar": {
+        "name": "High Speed CrossBar",
+        "data_file": "hw/ip/tlul/data/tlul.prj.hjson",
+        "href": "/hw/ip/tlul#top",
+        "report": "/hw/top_earlgrey/ip/xbar_main/dv/autogen"
+    },
+    "ibex": {
+        "name": "Ibex",
+        "data_file": "hw/ip/rv_core_ibex/data/rv_core_ibex.hjson",
+        "href": "/hw/ip/rv_core_ibex#top",
+        "report": null
+    },
+    "interrupt-controller": {
+        "name": "Interrupt Controller",
+        "data_file": "hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson",
+        "href": "/hw/top_earlgrey/ip_autogen/rv_plic#top",
+        "report": null
+    },
+    "debug-module": {
+        "name": "Debug Module",
+        "data_file": "hw/ip/rv_dm/data/rv_dm.hjson",
+        "href": "/hw/ip/rv_dm#top",
+        "report": "/hw/ip/rv_dm/dv"
+    },
+    "rom": {
+        "name": "ROM",
+        "data_file": "hw/ip/rom_ctrl/data/rom_ctrl.hjson",
+        "href": "/hw/ip/rom_ctrl#top",
+        "report": "/hw/ip/rom_ctrl/dv"
+    },
+    "main-sram": {
+        "name": "Main SRAM",
+        "data_file": "hw/ip/sram_ctrl/data/sram_ctrl.hjson",
+        "href": "/hw/ip/sram_ctrl#top",
+        "report": "/hw/ip/sram_ctrl_main/dv"
+    },
+    "key-manager": {
+        "name": "Key Manager",
+        "data_file": "hw/ip/keymgr/data/keymgr.hjson",
+        "href": "/hw/ip/keymgr#top",
+        "report": "/hw/ip/keymgr/dv"
+    },
+    "otbn": {
+        "name": "OTBN",
+        "data_file": "hw/ip/otbn/data/otbn.hjson",
+        "href": "/hw/ip/otbn#top",
+        "report": "/hw/ip/otbn/dv/uvm"
+    },
+    "aes": {
+        "name": "AES",
+        "data_file": "hw/ip/aes/data/aes.hjson",
+        "href": "/hw/ip/aes#top",
+        "report": "/hw/ip/aes_unmasked/dv"
+    },
+    "kmac": {
+        "name": "KMAC",
+        "data_file": "hw/ip/kmac/data/kmac.hjson",
+        "href": "/hw/ip/kmac#top",
+        "report": "/hw/ip/kmac_unmasked/dv"
+    },
+    "hmac": {
+        "name": "HMAC",
+        "data_file": "hw/ip/hmac/data/hmac.hjson",
+        "href": "/hw/ip/hmac#top",
+        "report": "/hw/ip/hmac/dv"
+    },
+    "flash": {
+        "name": "Flash",
+        "data_file": "hw/ip/flash_ctrl/data/flash_ctrl.hjson",
+        "href": "/hw/ip/flash_ctrl#top",
+        "report": "/hw/ip/flash_ctrl/dv"
+    },
+    "edn": {
+        "name": "EDN",
+        "data_file": "hw/ip/edn/data/edn.hjson",
+        "href": "/hw/ip/edn#top",
+        "report": "/hw/ip/edn/dv"
+    },
+    "csrng": {
+        "name": "CSRNG",
+        "data_file": "hw/ip/csrng/data/csrng.hjson",
+        "href": "/hw/ip/csrng#top",
+        "report": "/hw/ip/csrng/dv"
+    },
+    "entropy-source": {
+        "name": "Entropy Source",
+        "data_file": "hw/ip/entropy_src/data/entropy_src.hjson",
+        "href": "/hw/ip/entropy_src#top",
+        "report": "/hw/ip/entropy_src/dv"
+    },
+    "spi-host-0": {
+        "name": "SPI Host",
+        "data_file": "hw/ip/spi_host/data/spi_host.hjson",
+        "href": "/hw/ip/spi_host#top",
+        "report": "/hw/ip/spi_host/dv"
+    },
+    "spi-host-1": {
+        "name": "SPI Host",
+        "data_file": "hw/ip/spi_host/data/spi_host.hjson",
+        "href": "/hw/ip/spi_host#top",
+        "report": "/hw/ip/spi_host/dv"
+    },
+    "usb": {
+        "name": "USB",
+        "data_file": "hw/ip/usbdev/data/usbdev.hjson",
+        "href": "/hw/ip/usbdev#top",
+        "report": "/hw/ip/usbdev/dv"
+    },
+    "peripheral-crossbar": {
+        "name": "Peripheral Crossbar",
+        "data_file": "hw/ip/tlul/data/tlul.prj.hjson",
+        "href": "/hw/ip/tlul#top",
+        "report": "/hw/top_earlgrey/ip/xbar_peri/dv/autogen"
+    },
+    "otp-fuse-controller": {
+        "name": "OTP Fuse Controller",
+        "data_file": "hw/ip/otp_ctrl/data/otp_ctrl.hjson",
+        "href": "/hw/ip/otp_ctrl#top",
+        "report": "/hw/ip/otp_ctrl/dv"
+    },
+    "life-cycle": {
+        "name": "Life Cycle",
+        "data_file": "hw/ip/lc_ctrl/data/lc_ctrl.hjson",
+        "href": "/hw/ip/lc_ctrl#top",
+        "report": "/hw/ip/lc_ctrl/dv"
+    },
+    "alert-handler": {
+        "name": "Alert Handler",
+        "data_file": "hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson",
+        "href": "/hw/top_earlgrey/ip_autogen/alert_handler#top",
+        "report": "/hw/top_earlgrey/ip_autogen/alert_handler/dv"
+    },
+    "uart": {
+        "name": "UART",
+        "data_file": "hw/ip/uart/data/uart.hjson",
+        "href": "/hw/ip/uart#top",
+        "report": "/hw/ip/uart/dv"
+    },
+    "timers": {
+        "name": "Timers",
+        "data_file": "hw/ip/rv_timer/data/rv_timer.hjson",
+        "href": "/hw/ip/rv_timer#top",
+        "report": "/hw/ip/rv_timer/dv"
+    },
+    "gpio": {
+        "name": "GPIO",
+        "data_file": "hw/ip/gpio/data/gpio.hjson",
+        "href": "/hw/ip/gpio#top",
+        "report": "/hw/ip/gpio/dv"
+    },
+    "i2c": {
+        "name": "I2C",
+        "data_file": "hw/ip/i2c/data/i2c.hjson",
+        "href": "/hw/ip/i2c#top",
+        "report": "/hw/ip/i2c/dv"
+    },
+    "spi-device": {
+        "name": "SPI Device",
+        "data_file": "hw/ip/spi_device/data/spi_device.hjson",
+        "href": "/hw/ip/spi_device#top",
+        "report": "/hw/ip/spi_device/dv"
+    },
+    "pattern-generators": {
+        "name": "Pattern Generators",
+        "data_file": "hw/ip/pattgen/data/pattgen.hjson",
+        "href": "/hw/ip/pattgen#top",
+        "report": "/hw/ip/pattgen/dv"
+    },
+    "pwm": {
+        "name": "PWM",
+        "data_file": "hw/ip/pwm/data/pwm.hjson",
+        "href": "/hw/ip/pwm#top",
+        "report": "/hw/ip/pwm/dv"
+    },
+    "retention-sram": {
+        "name": "Retention SRAM",
+        "data_file": "hw/ip/sram_ctrl/data/sram_ctrl.hjson",
+        "href": "/hw/ip/sram_ctrl#top",
+        "report": "/hw/ip/sram_ctrl_ret/dv"
+    },
+    "power-manager": {
+        "name": "Power Manager",
+        "data_file": "hw/ip/pwrmgr/data/pwrmgr.hjson",
+        "href": "/hw/ip/pwrmgr#top",
+        "report": "/hw/ip/pwrmgr/dv"
+    },
+    "sysrst-controller": {
+        "name": "SYSRST Controller",
+        "data_file": "hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson",
+        "href": "/hw/ip/sysrst_ctrl#top",
+        "report": "/hw/ip/sysrst_ctrl/dv"
+    },
+    "aon-timers": {
+        "name": "AON Timer",
+        "data_file": "hw/ip/aon_timer/data/aon_timer.hjson",
+        "href": "/hw/ip/aon_timer#top",
+        "report": "/hw/ip/aon_timer/dv"
+    },
+    "clkrst-managers": {
+        "name": "CLK/RST Mangers",
+        "data_file": "hw/ip/clkmgr/data/clkmgr.hjson",
+        "href": "/hw/ip/clkmgr#top",
+        "report": "/hw/ip/clkmgr/dv"
+    },
+    "pinmux-padctrl": {
+        "name": "PINMUX/PADCTRL",
+        "data_file": "hw/ip/pinmux/data/pinmux.hjson",
+        "href": "/hw/ip/pinmux#top",
+        "report": null
+    },
+    "adc-controller": {
+        "name": "ADC Controller",
+        "data_file": "hw/ip/adc_ctrl/data/adc_ctrl.hjson",
+        "href": "/hw/ip/adc_ctrl#top",
+        "report": "/hw/ip/adc_ctrl/dv"
+    },
+    "sensor-control": {
+        "name": "Sensor Controller",
+        "data_file": "hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.hjson",
+        "href": "/hw/top_earlgrey/ip/sensor_ctrl#top",
+        "report": null
+    },
+    "analog-sensor-top": {
+        "name": "Analog Sensor Top",
+        "data_file": "hw/top_earlgrey/ip/ast/data/ast.hjson",
+        "href": "/hw/top_earlgrey/ip/ast#top",
+        "report": null
+    },
+    "padding": {
+        "name": "Padding",
+        "data_file": null,
+        "href": "/hw/top_earlgrey/ip/pinmux/doc/autogen/pinout_asic/",
+        "report": null
+    }
+}

--- a/util/site/build-docs.sh
+++ b/util/site/build-docs.sh
@@ -181,6 +181,10 @@ buildSite () {
     ${book_guides_env} mdbook ${mdbook_guides_args}
     # shellcheck disable=SC2086
     hugo ${hugo_args}
+
+    # Block diagram stats
+    mkdir -p "${build_dir}/reports"
+    python "${proj_root}/util/site/fetch_block_stats.py" "${build_dir}/reports/earlgrey-stats.json"
 }
 buildSite
 

--- a/util/site/fetch_block_stats.py
+++ b/util/site/fetch_block_stats.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Fetches stats for the hw blocks and bundles them into a json file.
+
+This script fetches the hw block data the diagram needs
+and bundles it into one json file.
+"""
+from urllib.request import urlopen
+import itertools as it
+import json
+from pathlib import Path
+import sys
+from typing import Tuple
+
+import hjson  # type: ignore
+
+REPO_TOP = Path(__file__).parents[2].resolve()
+
+
+def parse_report(path: str) -> Tuple[int, int]:
+    with urlopen(f'https://reports.opentitan.org{path}/latest/report.json') as response:
+        report = json.load(response)
+
+    # Extract all tests from the report.
+    testpoints = report['results']['testpoints']
+    tests_gen = it.chain(
+        (test for testpoint in testpoints for test in testpoint['tests']),
+        report['results']['unmapped_tests'],
+    )
+    # Convert into a dictionary to remove duplicates.
+    tests = {test['name']: test for test in tests_gen}
+
+    total_runs = sum(test['total_runs'] for test in tests.values())
+    total_passing = sum(test['passing_runs'] for test in tests.values())
+
+    return (total_runs, total_passing)
+
+
+def parse_data_file(rel_path: str) -> Tuple[str, str, str]:
+    with (REPO_TOP / rel_path).open() as f:
+        block_data = hjson.load(f)
+
+    try:
+        return (
+            block_data['version'],
+            block_data['design_stage'],
+            block_data['verification_stage'],
+        )
+    except KeyError:
+        # Assumes the last value is the most recent
+        revision = block_data['revisions'][-1]
+        return (
+            revision['version'],
+            revision['design_stage'],
+            revision['verification_stage'],
+        )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        prog = sys.argv[0]
+        print(f"Usage: {prog} [output file]\nPlease provide an output file.")
+        exit(1)
+
+    output_file = sys.argv[1]
+
+    blocks_file = Path(__file__).parent / "blocks.json"
+    with blocks_file.open() as f:
+        blocks = json.load(f)
+
+    output = {}
+    for (name, block) in blocks.items():
+        print(f"fetching data for {name}")
+
+        block_output = {}
+        block_output['name'] = block['name']
+        block_output['href'] = block['href']
+        (
+            block_output['version'],
+            block_output['design_stage'],
+            block_output['verification_stage'],
+        ) = parse_data_file(block['data_file']) if block['data_file'] else (None, None, None)
+        (
+            block_output['total_runs'],
+            block_output['total_passing'],
+        ) = parse_report(block['report']) if block['report'] else (None, None)
+
+        output[name] = block_output
+
+    with open(output_file, 'w') as f:
+        json.dump(output, f, indent='  ')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds an interactive block diagram for earlgrey to the site.

Based on the excellent block diagram from this PR: https://github.com/lowRISC/opentitan/pull/17405

## Differences to the original block diagram

This version of the diagram was made to avoid introducing Node.js and its ecosystem into OpenTitan.

* Diagram styled using CSS grids, avoiding JavaScript hydration.
* Diagram specified declaratively in HTML. Should be easy to make others.
* Stats generated into a JSON file stored on the server.
* Client-side JavaScript fetches the stats and creates the tooltips.

There's a trade-off to using this diagram, but I personally think the benefits outweigh the drawbacks.

**Benefits**:

* Avoids introducing a new technology to OpenTitan (Node.js) which requires maintenance.
* Avoids adding large dependencies (Node.js, headless chrome, and puppeteer).
* Faster build time (only `fetch_block_stats.py` has to run, and ideally only nightly).
* Design/verification stages taken from the `.hjson` files, keeping them up to date.

**Drawbacks**:

* The CSS file is fairly large, though I've tried to document it thoroughly.
* Browser requires JavaScript to be enabled to see the tooltips (rest of diagram still works).

## Screenshots

Looks mostly the same as the original:

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/105280833/224030632-337df858-d0ca-4308-be66-50ae8e8a4a2d.png)

</details>

## TODO

Currently no styling for:

- [ ] Dual-lockstep ibex
- [ ] Crossbar crosses